### PR TITLE
the '0 shield bias' fix

### DIFF
--- a/game-controller/game_engine.go
+++ b/game-controller/game_engine.go
@@ -29,14 +29,13 @@ func (game *GameInfo) handleTeam(team *Team, wg *sync.WaitGroup) {
 
 	for team.Life > 0 && game.Running {
 		time.Sleep(1 * time.Second)
-
-		if team.Energy <= 0 {
+		radiationRatio = (float64)(game.Reading.Radiation-minRadiation) / (float64)(maxRadiation-minRadiation)
+		energyLoss = radiationRatio * maxEnergyLoss
+		if team.Energy-energyloss <= 0 {
 			team.Shield = false
 		}
 
 		if team.Shield {
-			radiationRatio = (float64)(game.Reading.Radiation-minRadiation) / (float64)(maxRadiation-minRadiation)
-			energyLoss = radiationRatio * maxEnergyLoss
 			team.Energy = int64(math.Max(float64(team.Energy)-math.Ceil(energyLoss), 0))
 			log.Printf("Team %s: Energy -%.2f\n", team.Name, energyLoss)
 			continue


### PR DESCRIPTION
If you keep your shield up as much as possible, you gain an advantage as it will use whatever energy is left to power the shield regardless whether you have enough to power it. This fixes that.